### PR TITLE
Configurado RestClient na versao 3.2 do Spring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.7'
+
+services:
+  keycloak:
+    container_name: admin
+    image: quay.io/keycloak/keycloak:20.0.3
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    ports:
+      - 8443:8080
+    command:
+      - start-dev

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.flowbot</groupId>

--- a/src/main/java/com/flowbot/application/Application.java
+++ b/src/main/java/com/flowbot/application/Application.java
@@ -11,9 +11,4 @@ public class Application {
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
-
-	@Bean
-	public RestTemplate restTemplate() {
-		return new RestTemplate();
-	}
 }

--- a/src/main/java/com/flowbot/application/Example.java
+++ b/src/main/java/com/flowbot/application/Example.java
@@ -1,0 +1,57 @@
+package com.flowbot.application;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClient.ResponseSpec.ErrorHandler;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+@Component
+public class Example {
+
+    private final RestClient restClient;
+
+    Predicate<HttpStatusCode> isNotFound = HttpStatus.NOT_FOUND::equals;
+
+    Predicate<HttpStatusCode> is5xx = HttpStatusCode::is5xxServerError;
+
+    public Example(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @PostConstruct
+    public void run() {
+        shouldBeMakeSuccesfullyApiCall().join();
+    }
+
+    public CompletableFuture<String> shouldBeMakeSuccesfullyApiCall() {
+        return CompletableFuture.supplyAsync(() -> restClient.post()
+                        .uri("/poc/whats/generate-code")
+                        .header(HttpHeaders.AUTHORIZATION, "x-api-key=1231243")
+                        .retrieve()
+                        .onStatus(isNotFound, notFoundHandler("def 1", "def 2"))
+                        .onStatus(is5xx, a5xxHandler("def1", "def2"))
+                        .body(String.class))
+                .thenApply(body -> {
+                    System.out.println(body);
+                    return body;
+                });
+    }
+
+    private ErrorHandler notFoundHandler(final String... args) {
+        return (req, res) -> {
+            throw new RuntimeException("not found handler imple......");
+        };
+    }
+
+    private ErrorHandler a5xxHandler(final String... args) {
+        return (req, res) -> {
+            throw new RuntimeException("not found handler imple......");
+        };
+    }
+}

--- a/src/main/java/com/flowbot/application/configs/RestClientConfig.java
+++ b/src/main/java/com/flowbot/application/configs/RestClientConfig.java
@@ -1,0 +1,20 @@
+package com.flowbot.application.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        final var factory = new JdkClientHttpRequestFactory();
+        factory.setReadTimeout(30);
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .build();
+    }
+}

--- a/src/main/java/com/flowbot/application/configs/RestClientConfig.java
+++ b/src/main/java/com/flowbot/application/configs/RestClientConfig.java
@@ -1,5 +1,6 @@
 package com.flowbot.application.configs;
 
+import com.flowbot.application.configs.properties.BotBuilderEngineApiProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
@@ -9,11 +10,12 @@ import org.springframework.web.client.RestClient;
 public class RestClientConfig {
 
     @Bean
-    public RestClient restClient() {
+    public RestClient restClient(final BotBuilderEngineApiProperties properties) {
         final var factory = new JdkClientHttpRequestFactory();
-        factory.setReadTimeout(30);
+        factory.setReadTimeout(properties.getReadTimeout());
 
         return RestClient.builder()
+                .baseUrl(properties.getBaseUrl())
                 .requestFactory(factory)
                 .build();
     }

--- a/src/main/java/com/flowbot/application/configs/SecurityConfig.java
+++ b/src/main/java/com/flowbot/application/configs/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.flowbot.application.configs;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -8,6 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+@ConditionalOnExpression("${keycloak.enabled:true} == true")
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {

--- a/src/main/java/com/flowbot/application/configs/properties/BotBuilderEngineApiProperties.java
+++ b/src/main/java/com/flowbot/application/configs/properties/BotBuilderEngineApiProperties.java
@@ -1,0 +1,27 @@
+package com.flowbot.application.configs.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "bot-builder")
+public class BotBuilderEngineApiProperties {
+    private String baseUrl;
+    private int readTimeout;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+}

--- a/src/main/resources/application-sandbox.yaml
+++ b/src/main/resources/application-sandbox.yaml
@@ -1,0 +1,9 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+
+keycloak:
+  enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,13 @@
 server:
   port: 8081
 
+keycloak:
+  enabled: true
+
+bot-builder:
+  read-timeout: 30000
+  base-url: https://bot-builder-engine-2242d70bd3b3.herokuapp.com
+
 logging:
   level:
     org:
@@ -18,7 +25,7 @@ spring:
             scope: openid, profile, email
         provider:
           keycloak:
-            issuer-uri: http://localhost:8080/realms/bot-flow
+            issuer-uri: http://localhost:8443/realms/bot-flow
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8080/realms/bot-flow
+          issuer-uri: http://localhost:8443/realms/bot-flow


### PR DESCRIPTION
RestTemplate esta deprecado no spring v3, alterado para o RestClient
criado perfil de sandbox que ignora as configuracoes de oauth2 server e client para ser mais pratico nos testes